### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then in your configuration file (`.php-cs-fixer.php`) register fixers and use th
 return (new \PhpCsFixer\Config())
     ->registerCustomFixers(new \ErickSkrauch\PhpCsFixer\Fixers())
     ->setRules([
-        'ErickSkrauch\align_multiline_parameters' => true,
+        'ErickSkrauch/align_multiline_parameters' => true,
         // See the rest of the fixers below
     ]);
 ```


### PR DESCRIPTION
 The rules contain unknown fixers: "ErickSkrauch\align_multiline_parameters" (did you mean "ErickSkrauch/align_multiline_parameters"?).
 
 
![image](https://github.com/erickskrauch/php-cs-fixer-custom-fixers/assets/9253091/7fdc14ec-8f70-4c2b-a919-fa438ba669ea)
