### PR TITLE
Fix align_multiline_parameters breaking pass-by-reference params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix #17. The `AlignMultilineParametersFixer` doesn't account for the & reference token in function parameters (firecow).
 
 ## [1.3.1] - 2025-11-24
 ### Fixed

--- a/src/Fixer/FunctionNotation/AlignMultilineParametersFixer.php
+++ b/src/Fixer/FunctionNotation/AlignMultilineParametersFixer.php
@@ -32,6 +32,7 @@ use SplFileInfo;
  *     nameLength: positive-int,
  *     nameIndex: int,
  *     isVariadic: bool,
+ *     isReference: bool,
  * }
  */
 final class AlignMultilineParametersFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface {
@@ -171,6 +172,11 @@ function test(
                     }
                 }
 
+                if ($declarationAnalysis['isReference'] && $longestType === $declarationAnalysis['typeLength']) {
+                    // Reserve one column for the "&", which hugs the variable name like "..." does
+                    ++$longestType;
+                }
+
                 $analysedArguments[] = $declarationAnalysis;
             }
 
@@ -193,17 +199,22 @@ function test(
                 }
 
                 if ($this->configuration[self::C_VARIABLES] !== null) {
+                    // The "..." and "&" prefixes hug the variable name, so the whitespace we align
+                    // sits before them. The "&" spacing itself is left to the built-in fixers.
+                    $prefixIndex = $argument['nameIndex'];
                     if ($argument['isVariadic']) {
-                        $whitespaceIndex = $tokens->getPrevMeaningfulToken($argument['nameIndex']) - 1;
-                    } else {
-                        $whitespaceIndex = $argument['nameIndex'] - 1;
+                        $prefixIndex = $tokens->getPrevMeaningfulToken($prefixIndex);
                     }
 
+                    if ($argument['isReference']) {
+                        $prefixIndex = $tokens->getPrevMeaningfulToken($prefixIndex);
+                    }
+
+                    $whitespaceIndex = $prefixIndex - 1;
+
                     if ($this->configuration[self::C_VARIABLES] === true) {
-                        $alignLength = $longestType - $argument['typeLength'] + (int)$hasAtLeastOneTypedArgument;
-                        if ($argument['isVariadic']) {
-                            $alignLength -= 3; // 3 is the length of "..."
-                        }
+                        $prefixLength = ($argument['isVariadic'] ? 3 : 0) + ($argument['isReference'] ? 1 : 0);
+                        $alignLength = $longestType - $argument['typeLength'] - $prefixLength + (int)$hasAtLeastOneTypedArgument;
 
                         $appendix = str_repeat(' ', $alignLength);
                         if ($argument['typeLength'] > 0) {
@@ -237,6 +248,13 @@ function test(
         if ($variadicToken->isGivenKind(T_ELLIPSIS)) {
             $isVariadic = true;
             $searchIndex = $variadicTokenIndex;
+        }
+
+        $isReference = false;
+        $referenceTokenIndex = $tokens->getPrevMeaningfulToken($searchIndex);
+        if ($tokens[$referenceTokenIndex]->getContent() === '&') {
+            $isReference = true;
+            $searchIndex = $referenceTokenIndex;
         }
 
         if ($typeAnalysis !== null) {
@@ -280,6 +298,7 @@ function test(
             'nameLength' => $nameLength,
             'nameIndex' => $nameIndex,
             'isVariadic' => $isVariadic,
+            'isReference' => $isReference,
         ];
     }
 

--- a/tests/Fixer/FunctionNotation/AlignMultilineParametersFixerTest.php
+++ b/tests/Fixer/FunctionNotation/AlignMultilineParametersFixerTest.php
@@ -310,6 +310,87 @@ final class AlignMultilineParametersFixerTest extends AbstractFixerTestCase {
             ): void {}
             ',
         ];
+
+        yield 'pass-by-reference parameter (untyped)' => [
+            '<?php
+            function test(
+                string $a,
+                      &$b
+            ): void {}
+            ',
+            '<?php
+            function test(
+                string $a,
+                &$b
+            ): void {}
+            ',
+        ];
+
+        yield 'pass-by-reference parameter (multiple untyped)' => [
+            '<?php
+            function test(
+                GameRoom $gameRoom,
+                        &$status,
+                        &$statusCode
+            ): void {}
+            ',
+            '<?php
+            function test(
+                GameRoom $gameRoom,
+                &$status,
+                &$statusCode
+            ): void {}
+            ',
+        ];
+
+        yield 'pass-by-reference parameter (mixed typed and untyped)' => [
+            '<?php
+            function test(
+                string $a,
+                      &$b,
+                int    $c
+            ): void {}
+            ',
+            '<?php
+            function test(
+                string $a,
+                &$b,
+                int $c
+            ): void {}
+            ',
+        ];
+
+        yield 'pass-by-reference parameter (typed)' => [
+            '<?php
+            function test(
+                string &$a,
+                int     $b
+            ): void {}
+            ',
+            '<?php
+            function test(
+                string &$a,
+                int $b
+            ): void {}
+            ',
+        ];
+
+        yield 'pass-by-reference parameter (typed, multiple)' => [
+            '<?php
+            function test(
+                string &$a,
+                int    &$b,
+                bool    $c
+            ): void {}
+            ',
+            '<?php
+            function test(
+                string &$a,
+                int &$b,
+                bool $c
+            ): void {}
+            ',
+        ];
     }
 
     /**
@@ -556,6 +637,34 @@ final class AlignMultilineParametersFixerTest extends AbstractFixerTestCase {
                     protected readonly int | string|null $int = 0
                 ) {}
             }
+            ',
+        ];
+        yield 'intersection type is not treated as a reference' => [
+            '<?php
+            function test(
+                Iterator&Countable $a,
+                int                $b
+            ): void {}
+            ',
+            '<?php
+            function test(
+                Iterator&Countable $a,
+                int $b
+            ): void {}
+            ',
+        ];
+        yield 'intersection type passed by reference' => [
+            '<?php
+            function test(
+                Iterator&Countable &$a,
+                int                 $b
+            ): void {}
+            ',
+            '<?php
+            function test(
+                Iterator&Countable &$a,
+                int $b
+            ): void {}
             ',
         ];
     }


### PR DESCRIPTION
## Problem

The `AlignMultilineParametersFixer` does not account for the `&` reference token in function parameters. For untyped reference parameters like `&$status`, the fixer treats `typeLength` as `0`, causing it to insert a newline between `&` and `$var`:

```php
// Before (correct input)
function test(
    GameRoom $gameRoom,
    &$status,
    &$statusCode
)

// After (broken output)
function test(
    GameRoom             $gameRoom,
    &
                         $status,
    &
                         $statusCode
)
```

## Fix

- Detect `&` before the variable name (or before `...` for variadic reference) in `getDeclarationAnalysis()`
- Include `&` in `typeLength` (1 char) so the alignment calculation works correctly
- Add `isReference` flag to the declaration analysis
- In unalign mode (`C_VARIABLES => false`), remove whitespace between `&` and `$var` instead of inserting a space

## Result

```php
// Aligned (C_VARIABLES => true)
function test(
    GameRoom $gameRoom,
    &        $status,
    &        $statusCode
)

// Unaligned (C_VARIABLES => false)
function test(
    GameRoom $gameRoom,
    &$status,
    &$statusCode
)
```

## Tests

Added 3 test cases:
- Untyped reference parameter (`&$b` with typed sibling)
- Multiple untyped reference parameters (`&$status`, `&$statusCode` with typed sibling)
- Mixed typed and untyped with reference